### PR TITLE
fix otp spec

### DIFF
--- a/src/marketplace/routes.clj
+++ b/src/marketplace/routes.clj
@@ -21,7 +21,7 @@
 (s/def ::category-id int?)
 (s/def ::file-response (s/keys :req-un [::name ::category-id]))
 (s/def ::file-params (s/keys :req-un [::file ::name]))
-(s/def ::otp (s/and string? #(>= (count %) 6)))
+(s/def ::otp (s/and string? #(= (count %) 6)))
 
 (defn wrap-jwt-auth [handler]
   "Middleware jwt auth user."


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix one-time password (OTP) validation to require exactly six digits instead of six or more.