### PR TITLE
fix s3

### DIFF
--- a/src/marketplace/s3.clj
+++ b/src/marketplace/s3.clj
@@ -52,7 +52,7 @@
 (defn get-url-image
   "Build url image."
   [record]
-  (update record :photo (fn [_] (format "https://%s.s3.%s.amazonaws.com/%s" bucket-name region (:photo record)))))
+  (update record :photo (fn [_] (format "https://%s.s3.%s.amazonaws.com/media/%s" bucket-name region (:photo record)))))
 
 (comment
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fixed broken image URLs by adding the "media/" prefix.