### PR TITLE
fix regexp register

### DIFF
--- a/src/marketplace/migrations/categories_photo.clj
+++ b/src/marketplace/migrations/categories_photo.clj
@@ -1,7 +1,7 @@
 (ns marketplace.migrations.categories_photo
   (:require
-    [marketplace.s3 :as s3]
-    [marketplace.db :as db]))
+   [marketplace.s3 :as s3]
+   [marketplace.db :as db]))
 
 (defn migrate-up [config]
   (println config)

--- a/src/marketplace/users.clj
+++ b/src/marketplace/users.clj
@@ -10,8 +10,8 @@
 (defrecord User [first-name last-name email password])
 
 (s/def ::user-id uuid?)
-(s/def ::first-name (s/and string? #(re-matches #"\w{3,}" %)))
-(s/def ::last-name (s/and string? #(re-matches #"\w{3,}" %)))
+(s/def ::first-name (s/and string? #(re-matches #"[\p{L}]{3,}" %)))
+(s/def ::last-name (s/and string? #(re-matches #"[\p{L}]{3,}" %)))
 (s/def ::email (s/and string? #(re-matches #"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$" %)))
 (s/def ::password (s/and string? #(>= (count %) 8)))
 (s/def ::user (s/keys :req-un [::first-name ::last-name ::email ::password]))

--- a/test/marketplace/core_test.clj
+++ b/test/marketplace/core_test.clj
@@ -29,7 +29,26 @@
               slurp
               j/read-value)]
       (is (= true (string? token)))
-      (is (= "Login successful" message)))))
+      (is (= "Login successful" message))))
+
+  (testing "Register user with ua words"
+    (let [_ (user/delete "testerm1@urk.net")
+          {:strs [message token]}
+          (-> (mock/request :post "/api/v1/auth/register")
+              (mock/json-body {:first_name "Василь"
+                               :last_name "Васильській"
+                               :email "testerm1@urk.net"
+                               :password "8kz7cahpCCiJQAP!"})
+              router/app
+              :body
+              slurp
+              j/read-value)]
+      (is (= true (string? token)))
+      (is (= "Login successful" message))
+      (is (= (-> (user/delete "testerm1@urk.net")
+                 first
+                 :next.jdbc/update-count)
+             1)))))
 
 (deftest test-login-user
   (testing "Login user"


### PR DESCRIPTION
## Summary by Sourcery

Fix the user registration process to correctly handle names containing Unicode characters.

Bug Fixes:
- Fix the regular expression used to validate first and last names during user registration to support non-ASCII characters such as Cyrillic letters.
- Fix user registration to allow unicode letters in names

Tests:
- Add a test case to verify that user registration works correctly with names containing Unicode characters.